### PR TITLE
Fix text/image layer order of headers

### DIFF
--- a/src/components/start/hero.tsx
+++ b/src/components/start/hero.tsx
@@ -39,7 +39,8 @@ export type HeroSmallImageProps = BoxProps & {
 export function HeroSmallImage({ title, ...props }: HeroSmallImageProps) {
   return (
     <Box bg="gray.800" as="section" minH="140px" position="relative">
-      <Box py="12" position="relative" zIndex={1} {...props}>
+      <HeroImage />
+      <Box py="12" position="relative" {...props}>
         <Box mx="auto" textAlign="center" color="white">
           <Heading
             as="h1"
@@ -50,7 +51,6 @@ export function HeroSmallImage({ title, ...props }: HeroSmallImageProps) {
           </Heading>
         </Box>
       </Box>
-      <HeroImage />
     </Box>
   )
 }
@@ -58,7 +58,8 @@ export function HeroSmallImage({ title, ...props }: HeroSmallImageProps) {
 export function Hero(props: BoxProps) {
   return (
     <Box bg="gray.800" as="section" minH="140px" position="relative">
-      <Box py="56" position="relative" zIndex={1} {...props}>
+      <HeroImage />
+      <Box py="56" position="relative" {...props}>
         <Box
           maxW={{ base: "xl", md: "7xl" }}
           maxH="50vh"
@@ -83,7 +84,6 @@ export function Hero(props: BoxProps) {
           </Box>
         </Box>
       </Box>
-      <HeroImage />
     </Box>
   )
 }


### PR DESCRIPTION
If you place the image first and then the text, you don't need the z-index, which causes the text and its padding to be placed on top of each other, overlapping the header.